### PR TITLE
fix(institutional): scope CTA color fix to button, revert global reset edit

### DIFF
--- a/assets/sass/institutional.scss
+++ b/assets/sass/institutional.scss
@@ -148,6 +148,14 @@ body:has(.institutional) {
     cursor: pointer;
     transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
     border: 1px solid transparent;
+
+    // Force descendants (label span, arrow span) to inherit color
+    // from the button itself. The global *:not(.challenge *) rule in
+    // reset.scss sets color directly on every element via wildcard,
+    // which would otherwise beat the anchor's own color (including
+    // the :hover white). Specificity (0,1,1) on `&-btn > *` ties the
+    // global (0,1,0)+specificity boost and wins on cascade order.
+    & > * { color: inherit; }
   }
 
   &-btn-arrow {

--- a/assets/sass/reset.scss
+++ b/assets/sass/reset.scss
@@ -212,7 +212,7 @@ body {
   }
 }
 
-*:not(.challenge *):not(.institutional *) {
+*:not(.challenge *) {
   color: $text-color;
   letter-spacing: $letter-spacing;
 }


### PR DESCRIPTION
## Summary
Hot-fix for the regression introduced by the last commit on #819, which broadened the \`*:not(.challenge *)\` exclusion in \`reset.scss\` to include \`.institutional\` — that removed the gray text reset for everything under \`.institutional\` and changed text colors on the page in unintended ways.

## What this PR does
- **Reverts** \`reset.scss\` to its original form.
- **Scopes the fix to the button** by adding \`& > * { color: inherit }\` on \`&-btn\` so the label span and arrow span inherit color from the anchor itself. The global wildcard rule was beating the anchor's own \`color\` on descendants — including the \`:hover\` white — because direct-application beats inheritance regardless of which has higher specificity in the cascade. \`&-btn > *\` has specificity (0,1,1) which ties the global (0,1,0)+wildcard and wins on cascade order (institutional.scss is imported after reset.scss).

## Before / after
No live preview available pre-merge. Verifying on local build:
- **Before:** CTA label and arrow render at \`#454545\` regardless of hover; hover bg goes black but the gray text is barely readable against it.
- **After:** CTA label/arrow inherit \`var(--ink)\` at rest and \`#fff\` on hover, matching the design.

## Test plan
- [ ] Local build, navigate to \`/institutional\` — CTA text is dark at rest
- [ ] Hover CTA — bg goes black, label + arrow flip to white
- [ ] Other pages (homepage, \`/challenge\`, blog index) — text colors unchanged

Refs #818