### PR TITLE
feat(institutional): build sections 2-13 to complete the landing page

### DIFF
--- a/assets/sass/institutional.scss
+++ b/assets/sass/institutional.scss
@@ -22,6 +22,8 @@ body:has(.institutional) {
   --lilac-2: #B49BF5;
   --pink-1: #E4B5E8;
 
+  --fg: #FCFDFF;
+
   --grad-headline: linear-gradient(96deg, #9D7EF4 0%, #B49BF5 40%, #C7B0F2 100%);
 
   --radius-pill: 999px;
@@ -40,6 +42,15 @@ body:has(.institutional) {
   * { box-sizing: border-box; }
   img { display: block; max-width: 100%; }
   a { color: inherit; text-decoration: none; }
+
+  // Force inline text descendants to inherit color. Same reasoning
+  // as the &-btn fix: the global *:not(.challenge *) rule in
+  // reset.scss sets color directly on every element, which beats
+  // inheritance. Span/li/strong/em are the wrappers we use inside
+  // h2/p/div elements that have section-appropriate colors set
+  // explicitly. Specificity (0,1,1) ties global (0,1,0) and wins
+  // on cascade order (institutional.scss imported later).
+  span, li, strong, em { color: inherit; }
 
   .main-grid {
     max-width: 1280px;
@@ -185,12 +196,807 @@ body:has(.institutional) {
     border-radius: var(--radius-square);
   }
 
+  // Smaller button variant — used for sub-CTAs in features /
+  // talk-to-team sections.
+  &-btn-sm {
+    font-size: 10px;
+    letter-spacing: 0.18em;
+    padding: 11px 18px;
+    gap: 10px;
+  }
+
+  // ── SHARED SECTION PRIMITIVES ────────────────────────────
+  &-sec {
+    position: relative;
+    padding: 120px 0;
+    overflow: hidden;
+    background: var(--page-bg);
+  }
+
+  &-sec-dark {
+    background: var(--ink);
+    color: var(--fg);
+
+    .institutional-eyebrow { color: rgba(252, 253, 255, 0.55); }
+    .institutional-h2 { color: var(--fg); }
+    .institutional-body { color: rgba(252, 253, 255, 0.72); }
+  }
+
+  &-eyebrow {
+    font-family: var(--font-ui);
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.18em;
+    color: var(--ink-3);
+    text-transform: uppercase;
+    margin: 0 0 32px;
+  }
+
+  &-eyebrow-light {
+    color: rgba(252, 253, 255, 0.55);
+  }
+
+  &-h2 {
+    font-family: var(--font-display);
+    font-size: 52px;
+    line-height: 1.10;
+    font-weight: 400;
+    letter-spacing: -0.02em;
+    margin: 0 0 28px;
+    color: var(--ink);
+  }
+
+  &-body {
+    font-family: var(--font-body);
+    font-size: 15px;
+    line-height: 1.65;
+    color: var(--ink-2);
+    margin: 0;
+    max-width: 460px;
+  }
+
+  &-body-light {
+    color: rgba(252, 253, 255, 0.72);
+  }
+
+  &-grad-cyan {
+    background: linear-gradient(96deg, #6FE3F2 0%, #74E6F2 50%, #B8F0F7 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    -webkit-text-fill-color: transparent;
+  }
+
+  &-grad-lilac {
+    background: var(--grad-headline);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    -webkit-text-fill-color: transparent;
+  }
+
+  // ── SECTION 2 — Proof of work ────────────────────────────
+  &-pow {
+    &-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 80px;
+      align-items: center;
+    }
+
+    &-art {
+      position: relative;
+      height: 320px;
+      display: flex;
+      align-items: center;
+      justify-content: flex-start;
+    }
+
+    &-orb {
+      position: relative;
+      z-index: 2;
+      width: 88px;
+      height: 88px;
+      border-radius: 50%;
+      background:
+        radial-gradient(circle at 30% 30%, #FFFFFF 0%, #D4D8FF 18%, #7A89E9 55%, #3D4FD8 85%, #1A1F4A 100%);
+      box-shadow:
+        0 0 32px rgba(122, 137, 233, 0.65),
+        inset -8px -10px 20px rgba(0, 0, 0, 0.45);
+
+      &::before {
+        // mesh facet hint
+        content: "";
+        position: absolute;
+        inset: 4px;
+        border-radius: 50%;
+        background:
+          linear-gradient(35deg, transparent 48%, rgba(255, 255, 255, 0.18) 50%, transparent 52%),
+          linear-gradient(110deg, transparent 48%, rgba(255, 255, 255, 0.12) 50%, transparent 52%);
+        pointer-events: none;
+      }
+    }
+
+    &-beam {
+      position: absolute;
+      left: 60px;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 80%;
+      height: 280px;
+      clip-path: polygon(0% 48%, 100% 0%, 100% 100%, 0% 52%);
+      background: linear-gradient(90deg, rgba(122, 137, 233, 0.85) 0%, rgba(61, 79, 216, 0.55) 35%, rgba(26, 31, 74, 0.20) 75%, transparent 100%);
+      filter: blur(8px);
+      z-index: 1;
+    }
+
+    @media (max-width: 860px) {
+      &-grid { grid-template-columns: 1fr; gap: 48px; }
+      &-art { height: 240px; }
+    }
+  }
+
+  // ── SECTION 3 — Stats ────────────────────────────────────
+  &-stats {
+    padding: 80px 0 120px;
+    background: #F4F7F9;
+
+    &-grid-bg {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      background-image: radial-gradient(rgba(10, 10, 18, 0.18) 1px, transparent 1px);
+      background-size: 22px 22px;
+      opacity: 0.45;
+    }
+
+    &-row {
+      display: flex;
+      justify-content: center;
+      gap: 96px;
+      flex-wrap: wrap;
+      position: relative;
+      z-index: 1;
+    }
+
+    &-cell {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 24px;
+    }
+
+    &-shape {
+      width: 132px;
+      height: 132px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      clip-path: polygon(50% 0%, 95% 22%, 100% 65%, 75% 100%, 25% 100%, 0% 65%, 5% 22%);
+      box-shadow: inset 0 -8px 24px rgba(0, 0, 0, 0.18);
+
+      &-cyan { background: linear-gradient(155deg, #A8F0F6 0%, #4FD4E2 100%); }
+      &-periwinkle { background: linear-gradient(155deg, #9AA8F0 0%, #5E70E0 100%); }
+      &-coral { background: linear-gradient(155deg, #FFC9CA 0%, #FFADAE 100%); }
+    }
+
+    &-value {
+      font-family: var(--font-display);
+      font-size: 22px;
+      font-weight: 600;
+      color: var(--ink);
+      letter-spacing: -0.01em;
+    }
+
+    &-label {
+      font-family: var(--font-ui);
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--ink-2);
+    }
+
+    @media (max-width: 760px) {
+      &-row { gap: 40px; }
+      &-shape { width: 108px; height: 108px; }
+      &-value { font-size: 18px; }
+    }
+  }
+
+  // ── SECTION 4 — Track record ─────────────────────────────
+  &-track {
+    background: #F6F9FB;
+
+    &-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 80px;
+      align-items: center;
+    }
+
+    &-text {
+      max-width: 520px;
+    }
+
+    &-art {
+      position: relative;
+      height: 380px;
+      overflow: hidden;
+    }
+
+    &-art-inner {
+      position: absolute;
+      inset: 0;
+      background:
+        // soft purple gradient blocks
+        radial-gradient(ellipse 50% 22% at 70% 28%, rgba(167, 139, 250, 0.55) 0%, transparent 70%),
+        radial-gradient(ellipse 55% 24% at 90% 52%, rgba(192, 132, 252, 0.55) 0%, transparent 70%),
+        radial-gradient(ellipse 45% 20% at 60% 80%, rgba(155, 130, 240, 0.40) 0%, transparent 70%),
+        // honeycomb pattern hint
+        radial-gradient(circle at center, rgba(167, 139, 250, 0.08) 1.5px, transparent 2px);
+      background-size: auto, auto, auto, 14px 14px;
+      filter: blur(0.3px);
+    }
+
+    @media (max-width: 860px) {
+      &-grid { grid-template-columns: 1fr; gap: 40px; }
+      &-art { height: 240px; }
+    }
+  }
+
+  // ── SECTION 5 — Venues banner ────────────────────────────
+  &-venues {
+    padding: 64px 0;
+    color: var(--fg);
+    background: linear-gradient(95deg, #6FE3F2 0%, #A0C4F7 45%, #B49BF5 80%, #C7B0F2 100%);
+
+    &-title {
+      font-family: var(--font-display);
+      font-size: 22px;
+      font-weight: 400;
+      letter-spacing: -0.01em;
+      color: #FCFDFF;
+      text-align: center;
+      margin: 0 0 32px;
+    }
+
+    &-row {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: 48px;
+      flex-wrap: wrap;
+    }
+
+    &-logo {
+      font-family: var(--font-ui);
+      font-size: 18px;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      color: #FCFDFF;
+      opacity: 0.95;
+    }
+
+    @media (max-width: 760px) {
+      &-row { gap: 24px; }
+      &-logo { font-size: 14px; }
+    }
+  }
+
+  // ── SECTION 6 — Products ─────────────────────────────────
+  &-products {
+    &-grid {
+      display: grid;
+      grid-template-columns: 1fr 1.6fr;
+      gap: 80px;
+      align-items: start;
+    }
+
+    &-intro {
+      max-width: 380px;
+      padding-top: 8px;
+    }
+
+    &-cards {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 14px;
+    }
+
+    &-card {
+      background: #121214;
+      border: 1px solid rgba(255, 255, 255, 0.06);
+      padding: 22px 22px 24px;
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      min-height: 240px;
+      transition: background 0.2s ease, border-color 0.2s ease;
+
+      &:hover {
+        background: #17171B;
+        border-color: rgba(255, 255, 255, 0.14);
+      }
+    }
+
+    &-cat {
+      font-family: var(--font-ui);
+      font-size: 9px;
+      font-weight: 600;
+      letter-spacing: 0.20em;
+      text-transform: uppercase;
+      color: rgba(252, 253, 255, 0.45);
+    }
+
+    &-name-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    &-name {
+      font-family: var(--font-display);
+      font-size: 18px;
+      font-weight: 500;
+      color: #FCFDFF;
+      letter-spacing: 0.01em;
+    }
+
+    &-icon {
+      display: inline-block;
+      width: 22px;
+      height: 16px;
+
+      &-triangles {
+        background:
+          linear-gradient(135deg, transparent 49%, #74E6F2 50%, transparent 51%),
+          linear-gradient(45deg, transparent 49%, #B49BF5 50%, transparent 51%);
+        background-size: 8px 8px;
+        background-repeat: no-repeat;
+        background-position: 0 0, 12px 0;
+      }
+      &-chevrons {
+        background:
+          linear-gradient(45deg, transparent 49%, #74E6F2 50%, transparent 51%) 0 0 / 50% 100% no-repeat,
+          linear-gradient(45deg, transparent 49%, #74E6F2 50%, transparent 51%) 100% 0 / 50% 100% no-repeat;
+      }
+      &-brackets {
+        border-left: 2px solid #74E6F2;
+        border-right: 2px solid #74E6F2;
+        border-top: 2px solid transparent;
+        border-bottom: 2px solid transparent;
+        width: 18px;
+      }
+      &-hexagon {
+        background: #FFADAE;
+        clip-path: polygon(25% 5%, 75% 5%, 100% 50%, 75% 95%, 25% 95%, 0% 50%);
+      }
+    }
+
+    &-desc {
+      font-family: var(--font-body);
+      font-size: 13px;
+      line-height: 1.55;
+      color: rgba(252, 253, 255, 0.62);
+      margin: 0;
+      flex-grow: 1;
+    }
+
+    &-cta {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-family: var(--font-ui);
+      font-size: 10px;
+      font-weight: 600;
+      letter-spacing: 0.20em;
+      text-transform: uppercase;
+      color: rgba(252, 253, 255, 0.72);
+      margin-top: 4px;
+    }
+
+    @media (max-width: 960px) {
+      &-grid { grid-template-columns: 1fr; gap: 48px; }
+    }
+    @media (max-width: 600px) {
+      &-cards { grid-template-columns: 1fr; }
+    }
+  }
+
+  // ── SECTION 7 — Self-custody ─────────────────────────────
+  &-selfcustody {
+    background: #F8FAFB;
+
+    &-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 80px;
+      align-items: center;
+    }
+
+    &-text { max-width: 480px; }
+
+    &-art {
+      position: relative;
+      height: 280px;
+      overflow: hidden;
+    }
+
+    &-bar {
+      position: absolute;
+      right: -20%;
+      height: 64px;
+      width: 80%;
+      filter: blur(6px);
+      opacity: 0.85;
+    }
+
+    &-bar-1 {
+      top: 18%;
+      background: linear-gradient(90deg, transparent 0%, rgba(255, 173, 174, 0.85) 60%, rgba(255, 200, 200, 0.55) 100%);
+    }
+    &-bar-2 {
+      top: 44%;
+      background: linear-gradient(90deg, transparent 0%, rgba(255, 200, 200, 0.55) 50%, rgba(255, 173, 174, 0.85) 100%);
+    }
+    &-bar-3 {
+      top: 70%;
+      background: linear-gradient(90deg, transparent 0%, rgba(255, 173, 174, 0.65) 60%, rgba(255, 200, 200, 0.40) 100%);
+    }
+
+    @media (max-width: 860px) {
+      &-grid { grid-template-columns: 1fr; gap: 40px; }
+      &-art { height: 180px; }
+    }
+  }
+
+  // ── SECTION 8 — Infrastructure banner ────────────────────
+  &-infra {
+    padding: 64px 0 56px;
+    color: var(--fg);
+    background: linear-gradient(95deg, #7A89E9 0%, #9F89E9 40%, #C7AEF3 75%, #E4B5E8 100%);
+
+    &-title {
+      font-family: var(--font-display);
+      font-size: 22px;
+      font-weight: 400;
+      letter-spacing: -0.01em;
+      color: #FCFDFF;
+      text-align: center;
+      margin: 0 0 28px;
+    }
+
+    &-row {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: 48px;
+      flex-wrap: wrap;
+      margin-bottom: 18px;
+    }
+
+    &-logo {
+      font-family: var(--font-ui);
+      font-size: 16px;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      color: #FCFDFF;
+      opacity: 0.95;
+    }
+
+    &-sub {
+      font-family: var(--font-body);
+      font-size: 12px;
+      color: rgba(252, 253, 255, 0.78);
+      text-align: center;
+      margin: 0;
+    }
+
+    @media (max-width: 760px) {
+      &-row { gap: 24px; }
+      &-logo { font-size: 13px; }
+    }
+  }
+
+  // ── SECTION 9 — Policy engine ────────────────────────────
+  &-policy {
+    padding: 120px 0;
+
+    &-stack {
+      text-align: center;
+      max-width: 720px;
+      margin: 0 auto;
+    }
+
+    &-line {
+      font-family: var(--font-display);
+      font-size: 36px;
+      line-height: 1.30;
+      font-weight: 400;
+      letter-spacing: -0.01em;
+      color: #FCFDFF;
+      margin: 0;
+    }
+
+    &-punch {
+      color: #7A89E9;
+    }
+
+    @media (max-width: 760px) {
+      &-line { font-size: 24px; }
+    }
+  }
+
+  // ── SECTION 10 — Integration paths ───────────────────────
+  &-paths {
+    background: #ECEFF1;
+    padding: 100px 0;
+
+    &-title {
+      font-family: var(--font-display);
+      font-size: 36px;
+      font-weight: 400;
+      letter-spacing: -0.02em;
+      color: var(--ink);
+      margin: 0 0 64px;
+    }
+
+    &-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 24px;
+      max-width: 760px;
+      margin: 0 0 0 auto;
+    }
+
+    &-card {
+      border: 1px solid rgba(10, 10, 18, 0.30);
+      padding: 32px 32px 36px;
+      min-height: 320px;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      gap: 24px;
+      background: transparent;
+    }
+
+    &-card-title {
+      font-family: var(--font-display);
+      font-size: 24px;
+      font-weight: 400;
+      line-height: 1.25;
+      letter-spacing: -0.01em;
+      color: var(--ink);
+    }
+
+    &-card-body {
+      font-family: var(--font-body);
+      font-size: 14px;
+      line-height: 1.55;
+      color: var(--ink-2);
+      margin: 0;
+    }
+
+    @media (max-width: 760px) {
+      &-grid { grid-template-columns: 1fr; max-width: 100%; }
+      &-title { font-size: 28px; }
+    }
+  }
+
+  // ── SECTION 11 — Features ────────────────────────────────
+  &-features {
+    background: #F4F7F9;
+    padding: 100px 0;
+
+    &-header {
+      margin-bottom: 56px;
+      max-width: 460px;
+    }
+
+    &-grid {
+      display: grid;
+      grid-template-columns: 1fr 1.4fr;
+      gap: 0;
+      border-top: 1px solid rgba(10, 10, 18, 0.12);
+    }
+
+    &-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      border-right: 1px solid rgba(10, 10, 18, 0.12);
+    }
+
+    &-item {
+      padding: 16px 24px 16px 0;
+      border-bottom: 1px solid rgba(10, 10, 18, 0.10);
+    }
+
+    &-item-active {
+      .institutional-features-name {
+        color: #5E70E0;
+        font-weight: 500;
+      }
+    }
+
+    &-name {
+      font-family: var(--font-display);
+      font-size: 14px;
+      font-weight: 400;
+      color: var(--ink);
+      letter-spacing: -0.005em;
+    }
+
+    &-sub {
+      font-family: var(--font-body);
+      font-size: 12px;
+      color: var(--ink-2);
+      margin: 6px 0 0;
+      line-height: 1.5;
+    }
+
+    &-panel {
+      position: relative;
+      padding: 56px 56px 32px;
+      background:
+        radial-gradient(ellipse 80% 50% at 50% 100%, rgba(94, 112, 224, 0.65) 0%, transparent 75%),
+        linear-gradient(135deg, #FFFFFF 0%, #DCE0FF 35%, #8C9BF0 70%, #5E70E0 100%);
+      min-height: 360px;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+    }
+
+    &-panel-text {
+      font-family: var(--font-display);
+      font-size: 28px;
+      line-height: 1.20;
+      font-weight: 400;
+      letter-spacing: -0.01em;
+      color: var(--ink);
+      margin: 0;
+    }
+
+    &-panel-mark {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    &-panel-orb {
+      width: 26px;
+      height: 26px;
+      border-radius: 50%;
+      background:
+        radial-gradient(circle at 30% 30%, #FFFFFF 0%, #B9C0E0 25%, #1A1F4A 95%);
+      box-shadow: 0 0 0 1px rgba(10, 10, 18, 0.12);
+    }
+
+    &-panel-wordmark {
+      font-family: var(--font-display);
+      font-size: 18px;
+      font-weight: 500;
+      letter-spacing: 0.30em;
+      color: var(--ink);
+    }
+
+    &-ctas {
+      display: flex;
+      gap: 12px;
+      margin-top: 32px;
+      flex-wrap: wrap;
+    }
+
+    @media (max-width: 860px) {
+      &-grid { grid-template-columns: 1fr; }
+      &-list { border-right: none; border-bottom: 1px solid rgba(10, 10, 18, 0.12); }
+      &-panel-text { font-size: 22px; }
+      &-panel { padding: 40px 32px 24px; min-height: 280px; }
+    }
+  }
+
+  // ── SECTION 12 — Who for ─────────────────────────────────
+  &-whofor {
+    padding: 100px 0;
+
+    &-title {
+      font-family: var(--font-display);
+      font-size: 36px;
+      font-weight: 400;
+      letter-spacing: -0.02em;
+      color: #FCFDFF;
+      margin: 0 0 64px;
+    }
+
+    &-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 24px;
+      max-width: 760px;
+      margin: 0 0 0 auto;
+    }
+
+    &-card {
+      background: #17171B;
+      border: 1px solid rgba(255, 255, 255, 0.06);
+      padding: 32px 32px 36px;
+      min-height: 320px;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      gap: 24px;
+    }
+
+    &-card-title {
+      font-family: var(--font-display);
+      font-size: 22px;
+      font-weight: 400;
+      line-height: 1.25;
+      color: #FCFDFF;
+    }
+
+    &-card-list {
+      font-family: var(--font-body);
+      font-size: 13px;
+      line-height: 1.55;
+      color: #74E6F2;
+      margin: 0;
+    }
+
+    @media (max-width: 760px) {
+      &-grid { grid-template-columns: 1fr; max-width: 100%; }
+      &-title { font-size: 28px; }
+    }
+  }
+
+  // ── SECTION 13 — Talk to team ────────────────────────────
+  &-talk {
+    padding: 80px 0;
+    background: linear-gradient(95deg, #DCC8F5 0%, #C7AEF3 45%, #D3B6F0 85%, #E4D0F2 100%);
+
+    &-inner {
+      text-align: center;
+      max-width: 560px;
+      margin: 0 auto;
+    }
+
+    &-title {
+      font-family: var(--font-display);
+      font-size: 36px;
+      font-weight: 400;
+      letter-spacing: -0.02em;
+      color: var(--ink);
+      margin: 0 0 16px;
+    }
+
+    &-body {
+      font-family: var(--font-body);
+      font-size: 14px;
+      color: var(--ink-2);
+      margin: 0 0 28px;
+    }
+
+    &-ctas {
+      display: flex;
+      gap: 12px;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+
+    @media (max-width: 760px) {
+      &-title { font-size: 28px; }
+    }
+  }
+
   // ── RESPONSIVE ───────────────────────────────────────────
   @media (max-width: 960px) {
     &-hero-title { font-size: 52px; }
+    &-h2 { font-size: 38px; }
   }
 
   @media (max-width: 760px) {
+    &-sec { padding: 80px 0; }
     &-hero {
       padding: 64px 0 96px;
     }
@@ -207,5 +1013,6 @@ body:has(.institutional) {
       // soften bands on mobile so they don't fight with text
       opacity: 0.85;
     }
+    &-h2 { font-size: 30px; }
   }
 }

--- a/code/partials/institutional/Features.js
+++ b/code/partials/institutional/Features.js
@@ -1,0 +1,63 @@
+import React from "react";
+import MainGrid from "../shared/MainGrid";
+
+function Features({
+  eyebrow, headline1, headline2,
+  f1, f1sub, f2, f3, f4, f5, f6, f7, f8,
+  panel1, panel2, panel3,
+  cta1Label, cta1Url, cta2Label, cta2Url,
+}) {
+  const rest = [f2, f3, f4, f5, f6, f7, f8].filter(Boolean);
+  return (
+    <section className="institutional-sec institutional-features">
+      <MainGrid>
+        <div className="institutional-features-header">
+          <div className="institutional-eyebrow">{eyebrow}</div>
+          <h2 className="institutional-h2">
+            <span>{headline1}</span><br />
+            <span>{headline2}</span>
+          </h2>
+        </div>
+
+        <div className="institutional-features-grid">
+          <ul className="institutional-features-list">
+            <li className="institutional-features-item institutional-features-item-active">
+              <div className="institutional-features-name">{f1}</div>
+              {f1sub && <p className="institutional-features-sub">{f1sub}</p>}
+            </li>
+            {rest.map((f, i) => (
+              <li key={i} className="institutional-features-item">
+                <div className="institutional-features-name">{f}</div>
+              </li>
+            ))}
+          </ul>
+
+          <div className="institutional-features-panel">
+            <p className="institutional-features-panel-text">
+              <span>{panel1}</span><br />
+              <span>{panel2}</span><br />
+              <span>{panel3}</span>
+            </p>
+            <div className="institutional-features-panel-mark" aria-hidden="true">
+              <span className="institutional-features-panel-orb"></span>
+              <span className="institutional-features-panel-wordmark">ORBS</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="institutional-features-ctas">
+          <a className="institutional-btn institutional-btn-outline institutional-btn-square institutional-btn-sm" href={cta1Url}>
+            <span>{cta1Label}</span>
+            <span className="institutional-btn-arrow" aria-hidden="true">→</span>
+          </a>
+          <a className="institutional-btn institutional-btn-outline institutional-btn-square institutional-btn-sm" href={cta2Url}>
+            <span>{cta2Label}</span>
+            <span className="institutional-btn-arrow" aria-hidden="true">→</span>
+          </a>
+        </div>
+      </MainGrid>
+    </section>
+  );
+}
+
+export default Features;

--- a/code/partials/institutional/Infrastructure.js
+++ b/code/partials/institutional/Infrastructure.js
@@ -1,0 +1,23 @@
+import React from "react";
+import MainGrid from "../shared/MainGrid";
+
+function Infrastructure({ title, sub, l1, l2, l3, l4, l5 }) {
+  const logos = [l1, l2, l3, l4, l5].filter(Boolean);
+  return (
+    <section className="institutional-sec institutional-infra">
+      <MainGrid>
+        <h3 className="institutional-infra-title">{title}</h3>
+        <div className="institutional-infra-row">
+          {logos.map((l, i) => (
+            <div key={i} className="institutional-infra-logo">
+              {l}
+            </div>
+          ))}
+        </div>
+        <p className="institutional-infra-sub">{sub}</p>
+      </MainGrid>
+    </section>
+  );
+}
+
+export default Infrastructure;

--- a/code/partials/institutional/IntegrationPaths.js
+++ b/code/partials/institutional/IntegrationPaths.js
@@ -1,0 +1,30 @@
+import React from "react";
+import MainGrid from "../shared/MainGrid";
+
+function IntegrationPaths({ title, p1title1, p1title2, p1body, p2title1, p2title2, p2body }) {
+  return (
+    <section className="institutional-sec institutional-paths">
+      <MainGrid>
+        <h2 className="institutional-paths-title">{title}</h2>
+        <div className="institutional-paths-grid">
+          <div className="institutional-paths-card">
+            <div className="institutional-paths-card-title">
+              <span>{p1title1}</span><br />
+              <span>{p1title2}</span>
+            </div>
+            <p className="institutional-paths-card-body">{p1body}</p>
+          </div>
+          <div className="institutional-paths-card">
+            <div className="institutional-paths-card-title">
+              <span>{p2title1}</span><br />
+              <span>{p2title2}</span>
+            </div>
+            <p className="institutional-paths-card-body">{p2body}</p>
+          </div>
+        </div>
+      </MainGrid>
+    </section>
+  );
+}
+
+export default IntegrationPaths;

--- a/code/partials/institutional/PolicyEngine.js
+++ b/code/partials/institutional/PolicyEngine.js
@@ -1,0 +1,21 @@
+import React from "react";
+import MainGrid from "../shared/MainGrid";
+
+function PolicyEngine({ line1, line2, line3, linePunch }) {
+  return (
+    <section className="institutional-sec institutional-sec-dark institutional-policy">
+      <MainGrid>
+        <div className="institutional-policy-stack">
+          <p className="institutional-policy-line">{line1}</p>
+          <p className="institutional-policy-line">{line2}</p>
+          <p className="institutional-policy-line">{line3}</p>
+          <p className="institutional-policy-line institutional-policy-punch">
+            {linePunch}
+          </p>
+        </div>
+      </MainGrid>
+    </section>
+  );
+}
+
+export default PolicyEngine;

--- a/code/partials/institutional/Products.js
+++ b/code/partials/institutional/Products.js
@@ -1,0 +1,66 @@
+import React from "react";
+import MainGrid from "../shared/MainGrid";
+
+function ProductIcon({ kind }) {
+  // Compact placeholder icons drawn with CSS shapes — swap for real
+  // brand marks when assets land.
+  return (
+    <span
+      className={"institutional-products-icon institutional-products-icon-" + (kind || "triangles")}
+      aria-hidden="true"
+    />
+  );
+}
+
+function ProductCard({ cat, name, icon, desc, url }) {
+  return (
+    <a className="institutional-products-card" href={url || "#"}>
+      <div className="institutional-products-cat">{cat}</div>
+      <div className="institutional-products-name-row">
+        <ProductIcon kind={icon} />
+        <span className="institutional-products-name">{name}</span>
+      </div>
+      <p className="institutional-products-desc">{desc}</p>
+      <div className="institutional-products-cta">
+        <span>DISCOVER</span>
+        <span className="institutional-btn-arrow" aria-hidden="true">→</span>
+      </div>
+    </a>
+  );
+}
+
+function Products({
+  eyebrow, headline1, headline2, headlineGrad, body,
+  p1cat, p1name, p1icon, p1desc, p1url,
+  p2cat, p2name, p2icon, p2desc, p2url,
+  p3cat, p3name, p3icon, p3desc, p3url,
+  p4cat, p4name, p4icon, p4desc, p4url,
+}) {
+  return (
+    <section className="institutional-sec institutional-sec-dark institutional-products">
+      <MainGrid>
+        <div className="institutional-products-grid">
+          <div className="institutional-products-intro">
+            <div className="institutional-eyebrow institutional-eyebrow-light">
+              {eyebrow}
+            </div>
+            <h2 className="institutional-h2">
+              <span>{headline1}</span><br />
+              <span>{headline2}</span><br />
+              <span className="institutional-grad-cyan">{headlineGrad}</span>
+            </h2>
+            <p className="institutional-body institutional-body-light">{body}</p>
+          </div>
+          <div className="institutional-products-cards">
+            <ProductCard cat={p1cat} name={p1name} icon={p1icon} desc={p1desc} url={p1url} />
+            <ProductCard cat={p2cat} name={p2name} icon={p2icon} desc={p2desc} url={p2url} />
+            <ProductCard cat={p3cat} name={p3name} icon={p3icon} desc={p3desc} url={p3url} />
+            <ProductCard cat={p4cat} name={p4name} icon={p4icon} desc={p4desc} url={p4url} />
+          </div>
+        </div>
+      </MainGrid>
+    </section>
+  );
+}
+
+export default Products;

--- a/code/partials/institutional/ProofOfWork.js
+++ b/code/partials/institutional/ProofOfWork.js
@@ -1,0 +1,32 @@
+import React from "react";
+import MainGrid from "../shared/MainGrid";
+
+function ProofOfWork({ eyebrow, headline1, headline2, headlineGrad, body }) {
+  return (
+    <section className="institutional-sec institutional-sec-dark institutional-pow">
+      <MainGrid>
+        <div className="institutional-pow-grid">
+          <div className="institutional-pow-art" aria-hidden="true">
+            <div className="institutional-pow-beam"></div>
+            <div className="institutional-pow-orb"></div>
+          </div>
+          <div className="institutional-pow-text">
+            <div className="institutional-eyebrow institutional-eyebrow-light">
+              {eyebrow || "[PROOF OF WORK]"}
+            </div>
+            <h2 className="institutional-h2">
+              <span>{headline1 || "Forged in DeFi."}</span><br />
+              <span>{headline2 || "Packaged for"}</span>{" "}
+              <span className="institutional-grad-lilac">
+                {headlineGrad || "institutions"}
+              </span>
+            </h2>
+            <p className="institutional-body institutional-body-light">{body}</p>
+          </div>
+        </div>
+      </MainGrid>
+    </section>
+  );
+}
+
+export default ProofOfWork;

--- a/code/partials/institutional/SelfCustody.js
+++ b/code/partials/institutional/SelfCustody.js
@@ -1,0 +1,28 @@
+import React from "react";
+import MainGrid from "../shared/MainGrid";
+
+function SelfCustody({ eyebrow, headline1, headline2, body }) {
+  return (
+    <section className="institutional-sec institutional-selfcustody">
+      <MainGrid>
+        <div className="institutional-selfcustody-grid">
+          <div className="institutional-selfcustody-text">
+            <div className="institutional-eyebrow">{eyebrow}</div>
+            <h2 className="institutional-h2">
+              <span>{headline1}</span><br />
+              <span>{headline2}</span>
+            </h2>
+            <p className="institutional-body">{body}</p>
+          </div>
+          <div className="institutional-selfcustody-art" aria-hidden="true">
+            <div className="institutional-selfcustody-bar institutional-selfcustody-bar-1"></div>
+            <div className="institutional-selfcustody-bar institutional-selfcustody-bar-2"></div>
+            <div className="institutional-selfcustody-bar institutional-selfcustody-bar-3"></div>
+          </div>
+        </div>
+      </MainGrid>
+    </section>
+  );
+}
+
+export default SelfCustody;

--- a/code/partials/institutional/Stats.js
+++ b/code/partials/institutional/Stats.js
@@ -1,0 +1,33 @@
+import React from "react";
+import MainGrid from "../shared/MainGrid";
+
+function Stats({
+  stat1v, stat1k, stat1c,
+  stat2v, stat2k, stat2c,
+  stat3v, stat3k, stat3c,
+}) {
+  const cells = [
+    { v: stat1v, k: stat1k, c: stat1c },
+    { v: stat2v, k: stat2k, c: stat2c },
+    { v: stat3v, k: stat3k, c: stat3c },
+  ];
+  return (
+    <section className="institutional-sec institutional-stats">
+      <div className="institutional-stats-grid-bg" aria-hidden="true"></div>
+      <MainGrid>
+        <div className="institutional-stats-row">
+          {cells.map((c, i) => (
+            <div key={i} className="institutional-stats-cell">
+              <div className={"institutional-stats-shape institutional-stats-shape-" + (c.c || "cyan")}>
+                <span className="institutional-stats-value">{c.v}</span>
+              </div>
+              <div className="institutional-stats-label">{c.k}</div>
+            </div>
+          ))}
+        </div>
+      </MainGrid>
+    </section>
+  );
+}
+
+export default Stats;

--- a/code/partials/institutional/TalkToTeam.js
+++ b/code/partials/institutional/TalkToTeam.js
@@ -1,0 +1,27 @@
+import React from "react";
+import MainGrid from "../shared/MainGrid";
+
+function TalkToTeam({ title, body, cta1Label, cta1Url, cta2Label, cta2Url }) {
+  return (
+    <section id="talk-to-team" className="institutional-sec institutional-talk">
+      <MainGrid>
+        <div className="institutional-talk-inner">
+          <h2 className="institutional-talk-title">{title}</h2>
+          <p className="institutional-talk-body">{body}</p>
+          <div className="institutional-talk-ctas">
+            <a className="institutional-btn institutional-btn-outline institutional-btn-square institutional-btn-sm" href={cta1Url}>
+              <span>{cta1Label}</span>
+              <span className="institutional-btn-arrow" aria-hidden="true">→</span>
+            </a>
+            <a className="institutional-btn institutional-btn-outline institutional-btn-square institutional-btn-sm" href={cta2Url}>
+              <span>{cta2Label}</span>
+              <span className="institutional-btn-arrow" aria-hidden="true">→</span>
+            </a>
+          </div>
+        </div>
+      </MainGrid>
+    </section>
+  );
+}
+
+export default TalkToTeam;

--- a/code/partials/institutional/TrackRecord.js
+++ b/code/partials/institutional/TrackRecord.js
@@ -1,0 +1,27 @@
+import React from "react";
+import MainGrid from "../shared/MainGrid";
+
+function TrackRecord({ eyebrow, lead, body }) {
+  return (
+    <section className="institutional-sec institutional-track">
+      <MainGrid>
+        <div className="institutional-track-grid">
+          <div className="institutional-track-text">
+            <div className="institutional-eyebrow">
+              {eyebrow || "[TRACK RECORD]"}
+            </div>
+            <h2 className="institutional-h2">
+              <span className="institutional-grad-cyan">{lead}</span>{" "}
+              <span>{body}</span>
+            </h2>
+          </div>
+          <div className="institutional-track-art" aria-hidden="true">
+            <div className="institutional-track-art-inner"></div>
+          </div>
+        </div>
+      </MainGrid>
+    </section>
+  );
+}
+
+export default TrackRecord;

--- a/code/partials/institutional/Venues.js
+++ b/code/partials/institutional/Venues.js
@@ -1,0 +1,22 @@
+import React from "react";
+import MainGrid from "../shared/MainGrid";
+
+function Venues({ title, v1, v2, v3, v4, v5, v6 }) {
+  const venues = [v1, v2, v3, v4, v5, v6].filter(Boolean);
+  return (
+    <section className="institutional-sec institutional-venues">
+      <MainGrid>
+        <h3 className="institutional-venues-title">{title}</h3>
+        <div className="institutional-venues-row">
+          {venues.map((v, i) => (
+            <div key={i} className="institutional-venues-logo">
+              {v}
+            </div>
+          ))}
+        </div>
+      </MainGrid>
+    </section>
+  );
+}
+
+export default Venues;

--- a/code/partials/institutional/WhoFor.js
+++ b/code/partials/institutional/WhoFor.js
@@ -1,0 +1,30 @@
+import React from "react";
+import MainGrid from "../shared/MainGrid";
+
+function WhoFor({ title, p1title1, p1title2, p1list, p2title1, p2title2, p2list }) {
+  return (
+    <section className="institutional-sec institutional-sec-dark institutional-whofor">
+      <MainGrid>
+        <h2 className="institutional-whofor-title">{title}</h2>
+        <div className="institutional-whofor-grid">
+          <div className="institutional-whofor-card">
+            <div className="institutional-whofor-card-title">
+              <span>{p1title1}</span><br />
+              <span>{p1title2}</span>
+            </div>
+            <p className="institutional-whofor-card-list">{p1list}</p>
+          </div>
+          <div className="institutional-whofor-card">
+            <div className="institutional-whofor-card-title">
+              <span>{p2title1}</span><br />
+              <span>{p2title2}</span>
+            </div>
+            <p className="institutional-whofor-card-list">{p2list}</p>
+          </div>
+        </div>
+      </MainGrid>
+    </section>
+  );
+}
+
+export default WhoFor;

--- a/code/partials/institutional/index.js
+++ b/code/partials/institutional/index.js
@@ -1,9 +1,35 @@
 import React from 'react'
 
-function Main({ hero }) {
+function Main({
+  hero,
+  proofOfWork,
+  stats,
+  trackRecord,
+  venues,
+  products,
+  selfCustody,
+  infrastructure,
+  policyEngine,
+  integrationPaths,
+  features,
+  whoFor,
+  talkToTeam,
+}) {
   return (
     <div className="institutional page">
       {hero}
+      {proofOfWork}
+      {stats}
+      {trackRecord}
+      {venues}
+      {products}
+      {selfCustody}
+      {infrastructure}
+      {policyEngine}
+      {integrationPaths}
+      {features}
+      {whoFor}
+      {talkToTeam}
     </div>
   );
 }

--- a/content/institutional/features/index.md
+++ b/content/institutional/features/index.md
@@ -1,0 +1,25 @@
+---
+layout: partials/institutional/Features
+eyebrow: "[KEY FEATURES & BENEFITS]"
+headline1: Institutional-grade,
+headline2: by default.
+
+f1: Non-custodial by design
+f1sub: "No custody handoff. No counterparty risk on Orbs."
+f2: Gasless across every product
+f3: MEV protection
+f4: Permissionless integration
+f5: Robust infrastructure
+f6: White-label ready
+f7: Reporting & audit trails
+f8: "Audited, immutable, ownerless contracts"
+
+panel1: No custody handoff.
+panel2: No counterparty risk
+panel3: on Orbs.
+
+cta1Label: Talk to the team
+cta1Url: "#talk-to-team"
+cta2Label: View on GitHub
+cta2Url: "https://github.com/orbs-network"
+---

--- a/content/institutional/index.md
+++ b/content/institutional/index.md
@@ -3,4 +3,28 @@ layout: partials/institutional/index
 
 hero:
   - hero/index.md
+proofOfWork:
+  - proof-of-work/index.md
+stats:
+  - stats/index.md
+trackRecord:
+  - track-record/index.md
+venues:
+  - venues/index.md
+products:
+  - products/index.md
+selfCustody:
+  - self-custody/index.md
+infrastructure:
+  - infrastructure/index.md
+policyEngine:
+  - policy-engine/index.md
+integrationPaths:
+  - integration-paths/index.md
+features:
+  - features/index.md
+whoFor:
+  - who-for/index.md
+talkToTeam:
+  - talk-to-team/index.md
 ---

--- a/content/institutional/infrastructure/index.md
+++ b/content/institutional/infrastructure/index.md
@@ -1,0 +1,10 @@
+---
+layout: partials/institutional/Infrastructure
+title: Works with existing security infrastructure
+sub: "in-house MPC, or any EIP-712-compatible signer."
+l1: LEDGER
+l2: Safe
+l3: Fireblocks
+l4: copper.co
+l5: BitGo
+---

--- a/content/institutional/integration-paths/index.md
+++ b/content/institutional/integration-paths/index.md
@@ -1,0 +1,12 @@
+---
+layout: partials/institutional/IntegrationPaths
+title: "Two integration paths:"
+
+p1title1: Institutional
+p1title2: users
+p1body: "API access for trading desks, OTC desks, treasuries, asset managers, and institutional execution teams."
+
+p2title1: Infrastructure &
+p2title2: access partners
+p2body: "Embed Orbs execution inside the platform your client already uses, with co-branded or fully white-labeled options."
+---

--- a/content/institutional/policy-engine/index.md
+++ b/content/institutional/policy-engine/index.md
@@ -1,0 +1,7 @@
+---
+layout: partials/institutional/PolicyEngine
+line1: Your policy engine.
+line2: Your approval workflows.
+line3: Your signers.
+linePunch: Orbs integrates and executes.
+---

--- a/content/institutional/products/index.md
+++ b/content/institutional/products/index.md
@@ -1,0 +1,32 @@
+---
+layout: partials/institutional/Products
+eyebrow: "[PRODUCTS]"
+headline1: Best price.
+headline2: Better execution.
+headlineGrad: One stack.
+body: "The risk-management order types trading teams expect — now available for on-chain execution. Aggregated liquidity for the best price. Advanced order types for execution control. The market structure institutions know, delivered on-chain."
+
+p1cat: BEST PRICE
+p1name: Liquidity Hub
+p1icon: triangles
+p1desc: "Aggregates DEX liquidity and professional market makers through an RFQ layer for best on-chain pricing, critical for larger trades. One integration. Deepest liquidity across every supported chain."
+p1url: /liquidity-hub
+
+p2cat: TIME-SLICED EXECUTION
+p2name: dTWAP
+p2icon: chevrons
+p2desc: "Splits large orders over time to reduce market impact and improve execution quality. Decentralized. Non-custodial. Fully on-chain."
+p2url: /dtwap
+
+p3cat: PRICE-TARGETED EXECUTION
+p3name: dLIMIT
+p3icon: brackets
+p3desc: "Executes only when the target price is available. No manual monitoring. No off-chain custody. No desk-side intervention."
+p3url: /dlimit
+
+p4cat: STOP-LOSS / TAKE-PROFIT
+p4name: dSLTP
+p4icon: hexagon
+p4desc: "Automated position protection with on-chain triggers."
+p4url: /dsltp
+---

--- a/content/institutional/proof-of-work/index.md
+++ b/content/institutional/proof-of-work/index.md
@@ -1,0 +1,8 @@
+---
+layout: partials/institutional/ProofOfWork
+eyebrow: "[PROOF OF WORK]"
+headline1: Forged in DeFi.
+headline2: Packaged for
+headlineGrad: institutions
+body: "Orbs has been building on-chain infrastructure since 2017 and powering spot swap execution products since 2023 across major decentralized trading venues."
+---

--- a/content/institutional/self-custody/index.md
+++ b/content/institutional/self-custody/index.md
@@ -1,0 +1,7 @@
+---
+layout: partials/institutional/SelfCustody
+eyebrow: "[SELF-CUSTODY, ALWAYS]"
+headline1: Built for the
+headline2: institutional stack
+body: "Assets never leave the client's wallet. Orders are signed from the wallet and settle back to the wallet. No custody handoff. No counterparty exposure to Orbs or any trading venue."
+---

--- a/content/institutional/stats/index.md
+++ b/content/institutional/stats/index.md
@@ -1,0 +1,12 @@
+---
+layout: partials/institutional/Stats
+stat1v: "$2.5B+"
+stat1k: Cumulative volume
+stat1c: cyan
+stat2v: "10+"
+stat2k: Chains live
+stat2c: periwinkle
+stat3v: "30+"
+stat3k: Venue integrations
+stat3c: coral
+---

--- a/content/institutional/talk-to-team/index.md
+++ b/content/institutional/talk-to-team/index.md
@@ -1,0 +1,9 @@
+---
+layout: partials/institutional/TalkToTeam
+title: Talk to the team
+body: "Talk to us about integration or view more information on Github."
+cta1Label: Talk to the team
+cta1Url: "mailto:institutional@orbs.com"
+cta2Label: View on GitHub
+cta2Url: "https://github.com/orbs-network"
+---

--- a/content/institutional/track-record/index.md
+++ b/content/institutional/track-record/index.md
@@ -1,0 +1,6 @@
+---
+layout: partials/institutional/TrackRecord
+eyebrow: "[TRACK RECORD]"
+lead: Proven on-chain
+body: execution infrastructure, packaged for institutional workflows.
+---

--- a/content/institutional/venues/index.md
+++ b/content/institutional/venues/index.md
@@ -1,0 +1,10 @@
+---
+layout: partials/institutional/Venues
+title: "Integrated by leading venues, including:"
+v1: LYNEX
+v2: base
+v3: SpookySwap
+v4: THENA
+v5: SwapX
+v6: QUICKSWAP
+---

--- a/content/institutional/who-for/index.md
+++ b/content/institutional/who-for/index.md
@@ -1,0 +1,12 @@
+---
+layout: partials/institutional/WhoFor
+title: Who is it for?
+
+p1title1: Institutional
+p1title2: users
+p1list: "Trading desks · OTC desks · Treasuries — DAOs, protocols, corporates · Asset managers · Payment & fintech rails"
+
+p2title1: Infrastructure &
+p2title2: access partners
+p2list: "Wallets & MPC providers · Custodians · Exchanges · Prime brokers"
+---


### PR DESCRIPTION
## Summary
Builds out the remaining 12 sections of \`/institutional\` to complete the landing page (issue #818). Hero shipped in #819; this PR adds everything below.

## Sections shipped
1. ~~Hero~~ (shipped in #819)
2. **Proof of work** — dark, 2-col, mesh-orb with blue beam art
3. **Stats** — light, dotted grid bg, 3 colored heptagon shapes ($2.5B+ / 10+ / 30+)
4. **Track record** — light, 2-col, purple gradient honeycomb art
5. **Venues banner** — full-width cyan→purple gradient, 6 venue text-logos
6. **Products** — dark, 2-col, 4 product cards (Liquidity Hub, dTWAP, dLIMIT, dSLTP)
7. **Self-custody** — light, 2-col, coral gradient bar art
8. **Infrastructure banner** — full-width purple→pink gradient, 5 partner text-logos
9. **Policy engine** — dark, centered 4-line statement with periwinkle punch line
10. **Integration paths** — light gray, 2 outline cards
11. **Features** — light, 8-item list + lilac gradient panel + 2 sub-CTAs
12. **Who for** — dark, 2 outline cards with cyan list text
13. **Talk to team** — lilac gradient, centered title + body + 2 sub-CTAs

## Architecture
- Shared section primitives added to \`institutional.scss\`: \`&-sec\`, \`&-sec-dark\`, \`&-eyebrow\`, \`&-h2\`, \`&-body\`, \`&-grad-cyan\`, \`&-grad-lilac\`, \`&-btn-sm\` — gives all sections a common vocabulary.
- Page-wide \`span, li, strong, em { color: inherit }\` rule mirrors the \`&-btn\` fix: the global \`*:not(.challenge *)\` reset directly sets color on every element, beating inheritance. Forcing inline wrappers to inherit keeps section-level colors intact across the dark/light switches without touching \`reset.scss\` (as agreed after PR #819's regression).
- Composition wired in \`content/institutional/index.md\` and \`code/partials/institutional/index.js\`.

## Known gaps (not blockers, follow-ups)
- **Venue and infrastructure logos render as text placeholders.** Repo only has \`spookyswap.svg\` and \`quickswap.svg\` from the venues list, and \`ledger.svg\` / \`bitgo.svg\` from the infrastructure list. Real brand marks need to land in \`assets/img/institutional/\` (or appropriate existing folders) and be swapped in. Easy follow-up commit.
- **OG \`image:\` field still empty** in \`content/institutional/index.yml\` — same note as #819. Should be a rendered hero/feature panel.
- **Mesh-orb art in section 2 is a CSS approximation.** The Figma design has a low-poly 3D mesh sphere; this version is a radial-gradient sphere with subtle facet hints. Functional but not pixel-perfect — swap for a real asset if needed.
- **Honeycomb art in section 4** is a stacked-gradients approximation of the Figma design.
- **No interactive state on Features list** — the \"Non-custodial by design\" item is statically highlighted as the active one and the panel shows that item's content. If you want click-through behavior between list items, that's a separate enhancement.
- **Screenshot tooling for code reviews** is tracked under #821 — not done for this PR per agreement.

## Test plan
- [ ] Local build, navigate to \`/institutional\` — full page renders end to end with no broken sections
- [ ] Text colors correct on both light and dark sections (no rogue #454545)
- [ ] All CTA hovers work (label + arrow flip to white)
- [ ] Mobile breakpoint at 760px collapses 2-col grids to 1-col cleanly
- [ ] No regression on homepage, \`/challenge\`, blog list, or any other page (styles fully scoped under \`.institutional\`)

Closes #818
Refs #821