### PR TITLE
feat(navbar): add Orbs Institutional under AI in Powered By Orbs menu

### DIFF
--- a/content/_shared/navbar/menu-links/overview/index.md
+++ b/content/_shared/navbar/menu-links/overview/index.md
@@ -12,5 +12,6 @@ links:
   - execution-services.md
   - orbs-agentic.md
   - ai-skills.md
+  - orbs-institutional.md
   - link-2.md
 ---

--- a/content/_shared/navbar/menu-links/overview/orbs-institutional.md
+++ b/content/_shared/navbar/menu-links/overview/orbs-institutional.md
@@ -1,0 +1,5 @@
+---
+layout: partials/navbar/components/menu-link
+---
+
+[Orbs Institutional](/institutional)


### PR DESCRIPTION
## Summary
Adds the \`/institutional\` landing page to the slide-out nav menu, positioned directly below the existing AI link in the \"Powered By Orbs\" section.

## Files
- New: \`content/_shared/navbar/menu-links/overview/orbs-institutional.md\` — link markdown matching the existing pattern (\`[Orbs Institutional](/institutional)\`)
- Updated: \`content/_shared/navbar/menu-links/overview/index.md\` — adds the new link slot after \`ai-skills.md\` and before \`link-2.md\`

No SCSS or React changes — pure content addition slotting into the existing menu-links pattern.

## Test plan
- [ ] Local build, open the slide-out nav menu
- [ ] Under \"Powered By Orbs\", \"Orbs Institutional\" appears directly below \"AI\"
- [ ] Clicking it routes to \`/institutional\`

**Not auto-merged.** Holding for your local check.