### PR TITLE
chore: add gog-based blog-pull helper, document new ingestion workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,16 +16,21 @@ Circle CI on commits to `main` → builds → deploys to GitHub Pages (`gh-pages
 
 ## Primary Workflow: Adding Blog Posts
 
-This repo is primarily used to add new blog posts. The user provides a Google Doc (either as a link or as downloaded files — a `.md` markdown export and a `.zip` HTML export containing images).
+This repo is primarily used to add new blog posts. The user provides a Google Doc as a link. Pull the doc + embedded images using the `scripts/blog-pull.sh` helper, which uses the [`gog`](https://gogcli.sh) CLI (already installed and authed on jeeves with `sukh@orbs.com`).
 
 ### Steps to Add a Blog Post
 
 1. **Create a branch** from `main` named `blog/<slug>` (e.g., `blog/Kodiak-Integrates-dSLTP`).
-2. **Create the slug** from the blog title (e.g., "Kodiak Integrates dSLTP" → `Kodiak-Integrates-dSLTP`)
-3. **Create directories:**
-   - `content/blog/<slug>/`
-   - `assets/img/blog/<slug>/`
-4. **Copy images** from the Google Doc export into `assets/img/blog/<slug>/`, naming them `image1.png`, `image2.png`, etc.
+2. **Create the slug** from the blog title (e.g., "Kodiak Integrates dSLTP" → `Kodiak-Integrates-dSLTP`).
+3. **Pull the doc + images:**
+   ```bash
+   scripts/blog-pull.sh <slug> <docId>
+   ```
+   - Extracts the doc ID from the URL: `docs.google.com/document/d/<docId>/edit`.
+   - Stages the markdown body at `/tmp/<slug>-pull/post.md`.
+   - Stages embedded images directly into `assets/img/blog/<slug>/` as `image1.<ext>`, `image2.<ext>`, … (extension preserved from source upload — usually `.jpg` or `.png`).
+   - Re-run with `--force` to overwrite if you need to re-pull.
+4. **Create `content/blog/<slug>/`** and the three files below.
 5. **Create 3 files** in `content/blog/<slug>/`:
 
 #### `index.yml`
@@ -43,7 +48,7 @@ subscribe:
 meta_description:
 meta_keywords:
 title: "Full Blog Title Here"
-image: /assets/img/blog/<slug>/image1.png
+image: /assets/img/blog/<slug>/image1.<ext>
 gdpr:
   - /_shared/gdpr/index.md
 ```
@@ -65,7 +70,7 @@ This file is identical for every blog post. No body content after frontmatter.
 ```markdown
 ---
 layout: partials/shared/mappers/blog-mapper
-image: /assets/img/blog/<slug>/image1.png
+image: /assets/img/blog/<slug>/image1.<ext>
 blogUrl: <slug>
 date: YYYY-MM-DD
 title: "Full Blog Title Here"
@@ -77,15 +82,25 @@ publish_at: YYYY-MM-DD HH:MM
 ---
 
 Full markdown body here. Images referenced as:
-![alt](/assets/img/blog/<slug>/image1.png)
+![alt](/assets/img/blog/<slug>/image1.<ext>)
 ```
 
 6. **Register the post** in `content/blog/blogs.md` — add `<slug>/blog.md` as the FIRST entry in the `list:` array (newest posts go on top).
 7. **Commit, push, and open a PR** targeting `main` for review before merging.
 
+### Converting the Pulled Markdown to `blog.md`
+
+The markdown coming out of `gog docs export` is close to publishable but needs a few mechanical edits — these are deterministic enough that the agent should do them automatically:
+
+- **Demote heading levels.** Google Docs exports document h1 as `**bold**` and section h2 as `###`. In `blog.md`, sections should be `##` and subsections `###`. Demote `###` → `##` and `####` → `###` throughout.
+- **Inline the hero image.** The first image is exported as a reference-style `![][image1]` with the base64 data appended at the file end. Replace with `![](/assets/img/blog/<slug>/image1.<ext>)` and drop the base64 ref-definition.
+- **Convert section separators.** Google Docs page/section breaks come through as `---` (horizontal rule). Replace with `<div class='line-separator'> </div>`.
+- **Strip the byline line.** The author line (e.g. `**By Ran Hammer · May 2026**`) is redundant — the template renders it from frontmatter. Remove it.
+- **Italic TL;DR opening.** Google Docs often italicises the TL;DR — keep it as-is, it renders fine.
+
 ### Formatting Rules for blog.md Content
 
-- Image paths must be absolute: `/assets/img/blog/<slug>/imageN.png`
+- Image paths must be absolute: `/assets/img/blog/<slug>/imageN.<ext>`
 - Use `##` and `###` for headings (not `#`)
 - Section dividers use: `<div class='line-separator'> </div>`
 - Links use standard markdown: `[text](url)`

--- a/scripts/blog-pull.sh
+++ b/scripts/blog-pull.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# blog-pull.sh — pull a Google Doc + embedded images for a new blog post.
+#
+# Usage:
+#   scripts/blog-pull.sh <slug> <docId> [--force]
+#
+# Example:
+#   scripts/blog-pull.sh Orbs-V5-Update 1Yqygde7OyrCQZyU3qPRMQy-yr0aR3-jaDfQ152ScfKU
+#
+# Outputs:
+#   /tmp/<slug>-pull/post.md          — raw markdown export from Google Docs
+#   /tmp/<slug>-pull/post.docx        — docx export (kept for reference)
+#   assets/img/blog/<slug>/imageN.<ext>  — embedded images, copied in order
+#
+# Requires:
+#   - gog CLI installed and authed (https://gogcli.sh)
+#   - GOG_ACCOUNT env var, or default account configured for sukh@orbs.com
+#
+# The script only stages files. The agent (or you) still composes
+# content/blog/<slug>/{index.yml,body.md,blog.md} and registers the post in
+# content/blog/blogs.md — see CLAUDE.md "Adding Blog Posts".
+
+set -euo pipefail
+
+ACCOUNT="${GOG_ACCOUNT:-sukh@orbs.com}"
+
+usage() {
+  cat >&2 <<EOF
+Usage: $0 <slug> <docId> [--force]
+
+  <slug>   e.g. Orbs-V5-Update
+  <docId>  Google Doc ID (the part of the URL between /d/ and /edit)
+  --force  Overwrite assets/img/blog/<slug>/ if it already has files
+
+Reads gog account from GOG_ACCOUNT (currently: $ACCOUNT).
+EOF
+  exit 2
+}
+
+if [[ $# -lt 2 ]]; then
+  usage
+fi
+
+SLUG="$1"
+DOC_ID="$2"
+FORCE="${3:-}"
+
+if [[ -z "$SLUG" || -z "$DOC_ID" ]]; then
+  usage
+fi
+
+if ! command -v gog >/dev/null 2>&1; then
+  echo "error: gog CLI not found on PATH — see https://gogcli.sh" >&2
+  exit 1
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$REPO_ROOT" ]]; then
+  echo "error: not inside a git repository" >&2
+  exit 1
+fi
+
+WORK_DIR="/tmp/${SLUG}-pull"
+IMG_DIR="${REPO_ROOT}/assets/img/blog/${SLUG}"
+
+# Guard against accidental overwrite of an existing image dir.
+if [[ -d "$IMG_DIR" ]] && [[ -n "$(ls -A "$IMG_DIR" 2>/dev/null)" ]]; then
+  if [[ "$FORCE" != "--force" ]]; then
+    echo "error: $IMG_DIR already has files; pass --force to overwrite" >&2
+    exit 1
+  fi
+  rm -rf "$IMG_DIR"
+fi
+
+rm -rf "$WORK_DIR"
+mkdir -p "$WORK_DIR" "$IMG_DIR"
+
+echo "[1/4] Exporting markdown..."
+gog docs export "$DOC_ID" \
+  --account "$ACCOUNT" \
+  --format md \
+  --out "$WORK_DIR/post.md" >/dev/null
+
+echo "[2/4] Downloading docx (for embedded images)..."
+gog drive download "$DOC_ID" \
+  --account "$ACCOUNT" \
+  --format docx \
+  --out "$WORK_DIR/post.docx" >/dev/null
+
+echo "[3/4] Extracting images from docx..."
+unzip -qo "$WORK_DIR/post.docx" -d "$WORK_DIR/docx-extracted/"
+
+MEDIA_DIR="$WORK_DIR/docx-extracted/word/media"
+if [[ -d "$MEDIA_DIR" ]]; then
+  # Copy media in lexical order — Google Docs names them image1, image2, ...
+  # which is also the insertion order in the document.
+  i=1
+  # shellcheck disable=SC2045
+  for src in $(ls -1 "$MEDIA_DIR" | sort -V); do
+    ext="${src##*.}"
+    cp "$MEDIA_DIR/$src" "$IMG_DIR/image${i}.${ext}"
+    i=$((i + 1))
+  done
+  IMG_COUNT=$((i - 1))
+else
+  IMG_COUNT=0
+fi
+
+echo "[4/4] Done."
+echo
+echo "Markdown:  $WORK_DIR/post.md"
+echo "Images:    $IMG_DIR ($IMG_COUNT file(s))"
+if [[ "$IMG_COUNT" -gt 0 ]]; then
+  ls -1 "$IMG_DIR" | sed 's/^/             /'
+fi
+echo
+echo "Next: compose content/blog/$SLUG/{index.yml,body.md,blog.md} per CLAUDE.md,"
+echo "      then register $SLUG/blog.md at the top of content/blog/blogs.md list:."

--- a/scripts/blog-pull.sh
+++ b/scripts/blog-pull.sh
@@ -50,6 +50,14 @@ if [[ -z "$SLUG" || -z "$DOC_ID" ]]; then
   usage
 fi
 
+# Restrict slug to safe characters — it gets interpolated into paths
+# (including rm -rf targets), so reject anything that could resolve
+# outside the intended scope.
+if [[ ! "$SLUG" =~ ^[A-Za-z0-9_-]+$ ]]; then
+  echo "error: slug must match [A-Za-z0-9_-]+, got: $SLUG" >&2
+  exit 2
+fi
+
 if ! command -v gog >/dev/null 2>&1; then
   echo "error: gog CLI not found on PATH — see https://gogcli.sh" >&2
   exit 1


### PR DESCRIPTION
## Summary

- Adds `scripts/blog-pull.sh <slug> <docId>` — pulls a Google Doc's markdown body and embedded images in one command using the `gog` CLI (already installed and authed on jeeves).
- Updates `CLAUDE.md` blog-post workflow to use the new script and documents the mechanical edits needed to convert the pulled markdown into `blog.md` format.

## Why

The previous workflow asked the operator to manually download `.md` + `.zip` exports from Google Docs every time and drop them somewhere on disk for the agent. That's per-post friction and the `.zip` HTML export contains scraped image URLs that need extra handling. `gog docs export` + `gog drive download --format docx` (then unzip and extract `word/media/`) is faster, scriptable, and produces cleaner output.

Closes #842.

## Test plan

- [x] `scripts/blog-pull.sh Orbs-V5-Update 1Yqygde7OyrCQZyU3qPRMQy-yr0aR3-jaDfQ152ScfKU` against the Orbs V5 doc — completes in ~3s, stages clean markdown and one 1280x641 JPEG hero image.
- [x] Script refuses to overwrite an existing `assets/img/blog/<slug>/` without `--force`.
- [x] CLAUDE.md reads cleanly end-to-end with the new flow.
- [ ] Next blog post (Orbs V5, #843) uses this script end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)