### PR TITLE
fix: correct team size to thirty in V5 post footer

### DIFF
--- a/content/blog/Orbs-V5-Update/blog.md
+++ b/content/blog/Orbs-V5-Update/blog.md
@@ -110,7 +110,7 @@ Committee Sync is the first step; the rest of V5 rolls out from here.
 
 Orbs is a decentralized Layer-3 (L3) blockchain designed specifically for advanced on-chain trading. Utilizing a Proof-of-Stake consensus, Orbs acts as a supplementary execution layer, facilitating complex logic and scripts beyond the native functionalities of smart contracts. Orbs-powered protocols, including dLIMIT, dTWAP, Liquidity Hub, and Perpetual Hub, push the boundaries of DeFi by introducing CeFi-level execution to on-chain trading.
 
-With a global team of over forty dedicated contributors based in Tel Aviv, London, New York, Tokyo, Seoul, Lisbon, and Limassol, Orbs continues to innovate at the forefront of blockchain technology.
+With a global team of over thirty dedicated contributors based in Tel Aviv, London, New York, Tokyo, Seoul, Lisbon, and Limassol, Orbs continues to innovate at the forefront of blockchain technology.
 
 For more information, visit www.orbs.com or join our community:
 


### PR DESCRIPTION
## Summary
- Change "over forty" → "over thirty" in the About Orbs footer of the Orbs V5 Update post.

## Why
Team size in the standard About Orbs boilerplate was overstated. Sarbloc flagged it on the live post.

## Scope
Limited to `content/blog/Orbs-V5-Update/blog.md` per request. The same "over forty" phrasing exists in `CLAUDE.md`'s canonical About Orbs block and older posts' footers — left untouched here.

## Test plan
- [ ] Single-word copy change; no build/runtime impact.