### PR TITLE
chore: blog post preview tooling + runbook step

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,19 @@ Full markdown body here. Images referenced as:
 ```
 
 6. **Register the post** in `content/blog/blogs.md` — add `<slug>/blog.md` as the FIRST entry in the `list:` array (newest posts go on top).
-7. **Commit, push, and open a PR** targeting `main` for review before merging.
+7. **Generate a preview** and share it for review (see *Previewing a Post* below).
+8. **Commit, push, and open a PR** targeting `main` for review before merging.
+
+### Previewing a Post (without a full build)
+
+The site can't be built locally (480+ pages, 10+ min — see *Do NOT Run Locally*), but a single post can be previewed without a build. `scripts/blog-preview.js` renders one post's `blog.md` into a standalone HTML file using the blog-inner template's exact DOM/classes (`code/partials/blog-inner/*.js` + `markdown.js`) and the real compiled `assets/css/index.css`, then screenshots it at desktop (1440) and mobile (390) widths with the cached Playwright chromium under `~/.cache/ms-playwright`. No `node_modules` or network needed.
+
+```bash
+node scripts/blog-preview.js <slug>
+# → /tmp/<slug>-preview/{preview.html,desktop.png,mobile.png}
+```
+
+Send the two PNGs to the user (e.g. via Telegram) as a pre-merge preview. Caveats: the post-body, headings, images, separators, and footer render faithfully; the **header layout and share icons are approximated** (they come from React components not rendered here), so don't read exact header spacing from the screenshot. The screenshots use tall fixed viewports, so expect trailing whitespace at the bottom; if a post is unusually long and gets cut off, bump the heights in the script.
 
 ### Converting the Pulled Markdown to `blog.md`
 

--- a/scripts/blog-preview.js
+++ b/scripts/blog-preview.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// Render a single blog post to a standalone HTML preview and screenshot it at
+// desktop + mobile widths — WITHOUT a full Cuttlebelle build (which takes 10+
+// min over 480+ pages). It replicates the blog-inner template's DOM structure
+// and class names (see code/partials/blog-inner/*.js + markdown.js) and applies
+// the real compiled assets/css/index.css, so typography, headings, images,
+// separators, and the footer render faithfully. The header/share-icons are
+// approximated (they come from React components not rendered here).
+//
+// Usage:  node scripts/blog-preview.js <slug>
+// Output: /tmp/<slug>-preview/{preview.html,desktop.png,mobile.png}
+//
+// Requires a Playwright chromium in ~/.cache/ms-playwright (already present on
+// jeeves). No node_modules needed — the markdown conversion is self-contained.
+
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+const slug = process.argv[2];
+if (!slug) {
+  console.error("usage: node scripts/blog-preview.js <slug>");
+  process.exit(1);
+}
+
+const ROOT = path.resolve(__dirname, "..");
+const blogPath = path.join(ROOT, `content/blog/${slug}/blog.md`);
+if (!fs.existsSync(blogPath)) {
+  console.error(`not found: ${blogPath}`);
+  process.exit(1);
+}
+const outDir = `/tmp/${slug}-preview`;
+fs.mkdirSync(outDir, { recursive: true });
+
+// --- parse frontmatter ---
+const raw = fs.readFileSync(blogPath, "utf8");
+const m = raw.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+const fm = {};
+m[1].split("\n").forEach((l) => {
+  const mm = l.match(/^(\w+):\s*(.*)$/);
+  if (mm) fm[mm[1]] = mm[2].replace(/^"|"$/g, "");
+});
+const body = m[2].trim();
+
+const fileUrl = (p) => "file://" + path.join(ROOT, p.replace(/^\//, ""));
+
+// --- inline: bold, links (mirrors markdown.js link handling for http vs rel) ---
+const inline = (s) =>
+  s
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/\[(.+?)\]\((.+?)\)/g, (_, t, h) =>
+      /^https?:/.test(h)
+        ? `<a href="${h}" rel="noopener" target='_blank'>${t}</a>`
+        : `<a href="${h}" rel="noopener">${t}</a>`
+    );
+
+// --- block-level markdown -> HTML with the repo's classes ---
+let html = "";
+for (let b of body.split(/\n\n+/)) {
+  b = b.trim();
+  if (!b) continue;
+  if (/^<\w/.test(b)) { html += b + "\n"; continue; } // raw html (line-separator)
+  let im = b.match(/^!\[(.*?)\]\((.+?)\)$/);
+  if (im) { html += `<figure class='image'><img src="${fileUrl(im[2])}" alt="${im[1]}"></figure>\n`; continue; }
+  let h = b.match(/^(#{2,4})\s+(.*)$/);
+  if (h) {
+    const lvl = h[1].length;
+    const cls = lvl === 2 ? "title-h2 sub-title" : `title-h${lvl}`;
+    const id = h[2].toLowerCase().replace(/[^\w]+/g, "-");
+    html += `<h${lvl} id="${id}" class='${cls}'>${inline(h[2])}</h${lvl}>\n`;
+    continue;
+  }
+  if (b.split("\n").every((l) => /^\s*[-*]\s+/.test(l))) {
+    html += "<ul>\n" + b.split("\n").map((l) => `<li class='text-p'>${inline(l.replace(/^\s*[-*]\s+/, ""))}</li>`).join("\n") + "\n</ul>\n";
+    continue;
+  }
+  html += `<p class='text-p'>${b.split("\n").map(inline).join("<br>")}</p>\n`;
+}
+
+const page = `<!doctype html><html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="stylesheet" href="${fileUrl("assets/css/index.css")}">
+<style>body{background:#fff;margin:0} .preview-pad{padding:24px}</style>
+</head><body><div class="preview-pad">
+<div class="blog-element">
+  <div class="single-blog-header header">
+    <h1 class="single-blog-header-title">${fm.title || slug}</h1>
+    <div class="single-blog-header-author-flex">
+      <div class="single-blog-header-author flex-start">
+        <span>${(fm.author || "").replace(/.*\//, "").replace(/\.md$/, "") || "Author"}</span>
+        <small>|</small><p class="blog-hedaer-date">${fm.date || ""}</p>
+      </div>
+    </div>
+  </div>
+  ${fm.image ? `<figure class="single-blog-bg"><img src="${fileUrl(fm.image)}" alt="blog"></figure>` : ""}
+  <div class="single-blog-body"><div class="single-blog-body-grid">
+${html}
+  </div></div>
+</div>
+</div></body></html>`;
+
+const htmlPath = path.join(outDir, "preview.html");
+fs.writeFileSync(htmlPath, page);
+
+// --- locate cached chromium ---
+function findChrome() {
+  const base = path.join(process.env.HOME, ".cache/ms-playwright");
+  for (const d of fs.existsSync(base) ? fs.readdirSync(base) : []) {
+    if (!d.startsWith("chromium-")) continue;
+    for (const sub of ["chrome-linux64/chrome", "chrome-linux/chrome"]) {
+      const p = path.join(base, d, sub);
+      if (fs.existsSync(p)) return p;
+    }
+  }
+  return null;
+}
+const chrome = findChrome();
+if (!chrome) {
+  console.error("No cached chromium found under ~/.cache/ms-playwright — preview.html written, screenshots skipped.");
+  console.log(htmlPath);
+  process.exit(0);
+}
+
+// Tall fixed viewports so the full article is captured (trailing whitespace is
+// expected; bump heights here if a post is unusually long).
+const shoot = (name, w, h) => {
+  const out = path.join(outDir, name);
+  execFileSync(chrome, [
+    "--headless", "--no-sandbox", "--hide-scrollbars",
+    "--force-device-scale-factor=1",
+    `--window-size=${w},${h}`,
+    `--screenshot=${out}`,
+    `file://${htmlPath}`,
+  ], { stdio: "ignore" });
+  return out;
+};
+const desktop = shoot("desktop.png", 1440, 6000);
+const mobile = shoot("mobile.png", 390, 10000);
+console.log(desktop);
+console.log(mobile);


### PR DESCRIPTION
## What
Adds a way to preview a single blog post visually **without** a full Cuttlebelle build (which takes 10+ min over 480+ pages).

- `scripts/blog-preview.js` — renders one post's `blog.md` to standalone HTML using the blog-inner template's exact DOM/class names (`code/partials/blog-inner/*.js` + `markdown.js`) and the real compiled `assets/css/index.css`, then screenshots desktop (1440) + mobile (390) with the cached Playwright chromium. No `node_modules` or network needed.
- `CLAUDE.md` — new *Previewing a Post* section + a preview step in the add-a-post checklist.

## Usage
```
node scripts/blog-preview.js <slug>
# → /tmp/<slug>-preview/{preview.html,desktop.png,mobile.png}
```

## Why
Lets the team eyeball typography/images/footer on a PR before merge, given local builds are off-limits.

## Testing
Ran against `Orbs-V5-Update` (incl. its table) and `Orbs-Institutional` — both render faithfully at both widths. Header/share-icons are approximated (noted in script + runbook); body/images/separators/footer are accurate.