### PR TITLE
Keep contact social channels current

### DIFF
--- a/content/contact/socials/blog/link-3.md
+++ b/content/contact/socials/blog/link-3.md
@@ -1,6 +1,6 @@
 ---
 layout: partials/contact/socials/LinkText
 text: Japanese -
-url: https://www.orbs.com/jp/blog/
-linkText: "www.orbs.com/jp/blog"
+url: https://medium.com/@orbs-japan-community
+linkText: "medium.com/@orbs-japan-community"
 ---

--- a/content/contact/socials/line/index.md
+++ b/content/contact/socials/line/index.md
@@ -1,6 +1,6 @@
 ---
 layout: partials/contact/socials/section
-title: Line & Discord
+title: Communication
 id: contact-line
 links:
   - link-3.md

--- a/content/contact/socials/line/link-1.md
+++ b/content/contact/socials/line/link-1.md
@@ -1,6 +1,6 @@
 ---
 layout: partials/contact/socials/LinkText
 text: Japanese -
-url: https://line.me/R/ti/p/%40vrf9558a
-linkText: "Line"
+url: https://lin.ee/yjbkD8U
+linkText: "LINE"
 ---

--- a/content/contact/socials/line/link-2.md
+++ b/content/contact/socials/line/link-2.md
@@ -1,6 +1,6 @@
 ---
 layout: partials/contact/socials/LinkText
 text: Korean -
-url: https://open.kakao.com/o/giYtuTRb
-linkText: "KakaoTalk"
+url: https://t.me/orbskr
+linkText: "Telegram"
 ---

--- a/content/contact/socials/telegram/link-3.md
+++ b/content/contact/socials/telegram/link-3.md
@@ -1,6 +1,6 @@
 ---
 layout: partials/contact/socials/LinkText
 text: Japanese -
-url: https://t.me/joinchat/G0HZhBQssmZ05v6sp_G6jg
-linkText: "@OrbsJapan"
+url: https://t.me/orbsjpannouncements
+linkText: "@orbsjpannouncements"
 ---


### PR DESCRIPTION
Constraint: Update only English contact Social channels content without running the full Cuttlebelle build.

Rejected: Full local site rebuild | CLAUDE.md warns it is slow and unnecessary for this content-only link update.

Confidence: high

Scope-risk: narrow

Directive: Keep future social channel changes in content/contact/socials so generated pages stay data-driven.

Tested: Inspected git diff and mirrored the changed links in the local site/contact preview output.

Not-tested: Full Cuttlebelle build was intentionally not run per repository guidance.