### PR TITLE
blog: publish QuickSwap PHU 2.0 post (list + today's date)

### DIFF
--- a/content/blog/QuickSwap-Adopts-Orbs-Perpetual-Hub-Ultra-2-0/blog.md
+++ b/content/blog/QuickSwap-Adopts-Orbs-Perpetual-Hub-Ultra-2-0/blog.md
@@ -2,7 +2,7 @@
 layout: partials/shared/mappers/blog-mapper
 image: /assets/img/blog/QuickSwap-Adopts-Orbs-Perpetual-Hub-Ultra-2-0/image1.png
 blogUrl: QuickSwap-Adopts-Orbs-Perpetual-Hub-Ultra-2-0
-date: 2026-07-13
+date: 2026-07-14
 title: "QuickSwap Adopts Orbs Perpetual Hub Ultra 2.0"
 author:
   - /blog/common/authors/RanHammer.md

--- a/content/blog/blogs.md
+++ b/content/blog/blogs.md
@@ -1,6 +1,7 @@
 ---
 layout: partials/shared/mappers/blog-list-mapper
 list:
+  - QuickSwap-Adopts-Orbs-Perpetual-Hub-Ultra-2-0/blog.md
   - introducing-perpetual-hub-ultra-2.0/blog.md
   - SushiSwap-Integrates-dSLTP/blog.md
   - Orbs-Institutional/blog.md


### PR DESCRIPTION
Publishes the QuickSwap Perpetual Hub Ultra 2.0 post (live unlisted since #862): `date` → 2026-07-14, registered at the top of `content/blog/blogs.md`. No `publish_at` — visible in the listing + RSS as soon as the deploy lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)