### PR TITLE
fix(rss): exclude not-yet-published posts from the feed

### DIFF
--- a/build-rss-feed.js
+++ b/build-rss-feed.js
@@ -22,6 +22,25 @@ async function generateRss() {
 
     for (const blogHtml of blogsHtml) {
 
+        // Skip posts scheduled for the future. The publish_at gate is CLIENT-side
+        // (assets/js/blogs/index.js), so the built HTML contains every post —
+        // including ones not yet live. Without this filter the feed leaks a
+        // scheduled post the moment it deploys, days before its publish time.
+        //
+        // The condition mirrors the client gate exactly (no publish_at -> live;
+        // present but unparseable -> not live) so the feed and the listing can't
+        // disagree. NOTE: this runs at BUILD time, so a post enters the feed on
+        // the first build after its publish time — late, not early. Late is the
+        // safe direction; early is the bug being fixed.
+        const publishAt = blogHtml.attrs['data-publish-at']
+        const isLive = !publishAt
+            || (!isNaN(new Date(publishAt)) && Date.now() > new Date(publishAt).getTime())
+
+        if (!isLive) {
+            console.log(`rss: skipping not-yet-published post (publish_at=${publishAt})`)
+            continue
+        }
+
         const titleNode = blogHtml.querySelector('.blog-list-blog-title').childNodes[0]
 
         const author = blogHtml.querySelector('.blog-list-blog-author').querySelector('a')


### PR DESCRIPTION
## Problem
The `publish_at` gate is **client-side** (`assets/js/blogs/index.js:34`), so the built HTML contains every post — including scheduled ones. `build-rss-feed.js` parsed that HTML with no `publish_at` filter, so **a scheduled post entered `rss.xml` the moment it deployed**, potentially days before its publish time.

Found while shipping the OIP-9 / Orbs DAO post (#869), which is embargoed to Mon 17 Aug 12:00 UTC. Not introduced by that PR — it affected every scheduled post (SushiSwap dSLTP, Ring Protocol).

## Fix
One filter at the top of the item loop. Mirrors the client gate **exactly** (no `publish_at` → live; present but unparseable → not live) so the feed and the listing can't disagree. Skips are logged, not silent.

## Verification
Ran the real script against a fixture (3 posts: no gate / past / future) — before and after:

**Before (current `main`):** Post A, Post B, **Post C (FUTURE)** ← the leak
**After (this PR):** Post A, Post B — plus `rss: skipping not-yet-published post (publish_at=2026-08-17T12:00:00Z)`

## ⚠️ Known trade-off (Codex P1 — accepted, not overlooked)
This runs at **build** time, so a post enters the feed on the first build *after* its publish time — late rather than early. Codex correctly flagged that "late" can be a long time: **the longest gap between `main` commits in the last 6 months is 21 days**, and two recent weeks had none.

Accepted deliberately, because the two failure directions are not symmetric:
- **Early (status quo)** = broken embargo on a coordinated announcement. Unrecoverable.
- **Late (this PR)** = feed catches up on the next deploy. Recoverable, and the post is live on-site regardless.

The complete fix is a scheduled rebuild (daily CircleCI cron), which costs a CI build/day and a daily `gh-pages` commit — an operational decision left to @sarbloc rather than bundled in here. Happy to add it as a follow-up. Note CircleCI's legacy `triggers:` syntax is deprecated in favour of scheduled pipelines, so that change wants verifying it actually fires.

**For OIP-9 specifically:** any deploy after Mon 12:00 UTC picks it up. If nothing has deployed by then, ping me and I'll trigger one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)