### PR TITLE
fix(ci): fail fast with the real reason when gh-pages refuses the push

### DIFF
--- a/.github/workflows/refresh-rss.yml
+++ b/.github/workflows/refresh-rss.yml
@@ -129,9 +129,19 @@ jobs:
             # gh-pages commit can't trigger a deploy loop regardless.
             git commit -m "[ci skip] Refresh RSS feed"
 
-            if git push; then
+            if git push 2>"$RUNNER_TEMP/push.err"; then
               echo "published"
               exit 0
+            fi
+            cat "$RUNNER_TEMP/push.err"
+
+            # Only a non-fast-forward is worth retrying. A permissions or
+            # branch-protection rejection is terminal — retrying just repeats it
+            # and buries the real reason under a misleading "gh-pages moved"
+            # message (which is exactly what happened on the 2026-08-18 run).
+            if grep -qiE 'protected branch|not authorized|permission|denied|403' "$RUNNER_TEMP/push.err"; then
+              echo "::error::Push to gh-pages was refused by branch protection, not a race — retrying cannot help. gh-pages restricts pushes to an allowlist that does not include the github-actions app, so GITHUB_TOKEN cannot publish. Fix: add the github-actions app to the gh-pages push allowlist, or publish via a deploy key with write access (which is how CircleCI gets through)."
+              exit 1
             fi
 
             echo "push rejected — gh-pages moved (likely a CircleCI deploy); re-syncing and retrying"


### PR DESCRIPTION
## What failed

The 2026-08-18 scheduled run failed. It was the **first** run that ever reached the publish path — the 14th–17th all took the "feed unchanged, exit 0" branch, because OIP-9 only went live Monday 17th at 12:00 UTC.

The job reported `gh-pages moved (likely a CircleCI deploy); re-syncing and retrying`, three times. **That diagnosis was wrong.** The real rejection:

```
remote: - You're not authorized to push to this branch.
 ! [remote rejected] gh-pages -> gh-pages (protected branch hook declined)
```

## Root cause

`gh-pages` has a classic branch-protection **push restriction**:

- `users: [talkol]`
- `teams: []`
- `apps: []` ← empty

The github-actions app isn't on the allowlist, so `GITHUB_TOKEN` can't push. CircleCI is unaffected because it publishes via a **deploy key** (`add_ssh_keys` in `.circleci/config.yml`), and deploy keys bypass push restrictions.

## What this PR changes

Only the diagnosis. The retry loop treated *every* push failure as a race; a permissions/protection rejection is terminal, so retrying just repeats it and buries the real cause under a misleading message.

Now the stderr is classified: a genuine non-fast-forward still retries, while a protection/permission refusal fails immediately, printing the actual reason and the two ways to resolve it.

Verified against the real stderr from run 32084207608 (matches → fails fast) and a genuine non-fast-forward (no match → still retries).

## What this PR does NOT do

It does not grant the push access, so the nightly job will still fail until one of these is chosen:

1. **Add the github-actions app to the gh-pages push allowlist** — one API call, smallest change, easily reversed. Trade-off: any future workflow with `contents: write` could then push to gh-pages.
2. **Give the workflow a deploy key with write access** (mirrors how CircleCI already publishes) — no change to the allowlist, but needs a keypair and an Actions secret.
3. **Have the workflow trigger CircleCI instead of publishing directly** — reuses the already-sanctioned deploy path and adds no writer to gh-pages, but needs a CircleCI API token secret and burns a full ~10 min rebuild (only when the feed actually changes, so rare).

## Current impact

The OIP-9 post went live on-site Monday as scheduled, but is **missing from `rss.xml`** — the last deploy was Aug 13, before its publish time, so the build-time filter correctly excluded it then, and the nightly job that should have added it is blocked. Any deploy to `main` regenerates the feed and closes the gap immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
